### PR TITLE
Use browser-like headers and robust error handling when fetching external embeds; update image finder headers and tests

### DIFF
--- a/test/test_create_bsky_post.py
+++ b/test/test_create_bsky_post.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import argparse
+
+import requests
+
+import utils.create_bsky_post as bsky_post
+
+
+class DummyResponse:
+    def __init__(self, status_code: int = 200, text: str = "", content: bytes = b""):
+        self.status_code = status_code
+        self.text = text
+        self.content = content
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError(f"HTTP {self.status_code}")
+
+
+def test_fetch_embed_url_card_returns_none_on_blocked_url(monkeypatch):
+    def fake_get(url, **kwargs):
+        raise requests.HTTPError("HTTP 403")
+
+    monkeypatch.setattr(bsky_post, "_tracked_get", fake_get)
+
+    card = bsky_post.fetch_embed_url_card(
+        pds_url="https://bsky.social",
+        access_token="token",
+        url="https://example.com/blocked",
+    )
+
+    assert card is None
+
+
+def test_create_post_continues_when_embed_url_fetch_fails(monkeypatch):
+    recorded_payload: dict = {}
+
+    monkeypatch.setattr(
+        bsky_post,
+        "bsky_login_session",
+        lambda *args, **kwargs: {"accessJwt": "jwt", "did": "did:plc:test"},
+    )
+    monkeypatch.setattr(bsky_post, "parse_facets", lambda *args, **kwargs: [])
+    monkeypatch.setattr(bsky_post, "fetch_embed_url_card", lambda *args, **kwargs: None)
+
+    def fake_post(url, **kwargs):
+        recorded_payload.update(kwargs.get("json", {}))
+        return DummyResponse(status_code=200)
+
+    monkeypatch.setattr(bsky_post, "_tracked_post", fake_post)
+
+    args = argparse.Namespace(
+        pds_url="https://bsky.social",
+        handle="handle",
+        password="password",
+        text="hello world",
+        image=None,
+        alt_text=None,
+        lang=None,
+        reply_to=None,
+        embed_url="https://example.com/blocked",
+        embed_ref=None,
+        extra_facets=None,
+    )
+
+    bsky_post.create_post(args)
+
+    record = recorded_payload["record"]
+    assert record["text"] == "hello world"
+    assert "embed" not in record
+
+
+def test_fetch_embed_url_card_uses_browser_like_headers(monkeypatch):
+    calls = []
+
+    def fake_get(url, **kwargs):
+        calls.append({"url": url, **kwargs})
+        return DummyResponse(
+            status_code=200,
+            text='''<html><head>
+<meta property="og:title" content="Demo title"/>
+<meta property="og:description" content="Demo description"/>
+<meta property="og:image" content="/demo.jpg"/>
+</head></html>''',
+            content=b"jpeg-bytes",
+        )
+
+    monkeypatch.setattr(bsky_post, "_tracked_get", fake_get)
+    monkeypatch.setattr(bsky_post, "upload_file", lambda *args, **kwargs: {"$type": "blob"})
+
+    card = bsky_post.fetch_embed_url_card(
+        pds_url="https://bsky.social",
+        access_token="token",
+        url="https://example.com/path",
+    )
+
+    assert card is not None
+    assert calls[0]["headers"]["User-Agent"]
+    assert calls[0]["headers"]["Accept-Language"] == "en-US,en;q=0.9"
+    assert calls[0]["timeout"] == 15
+    assert calls[1]["url"] == "https://example.com/demo.jpg"
+    assert calls[1]["headers"]["Referer"] == "https://example.com/path"

--- a/test/test_image_finder.py
+++ b/test/test_image_finder.py
@@ -104,8 +104,9 @@ def test_jp_retries_429_then_returns_full_size(monkeypatch) -> None:
     assert url == "https://cdn.jetphotos.com/full/1/example.jpg"
     assert len(scraper.calls) == 2
     assert scraper.calls[0]["params"]["keywords"] == "EC-ABC"
-    assert scraper.calls[0]["headers"] is None
-    assert scraper.calls[1]["headers"] is None
+    assert scraper.calls[0]["headers"]["User-Agent"] == "test-agent"
+    assert scraper.calls[0]["headers"]["Referer"] == "https://www.jetphotos.com/"
+    assert scraper.calls[1]["headers"]["User-Agent"] == "test-agent"
 
 
 def test_planespotters_uses_largest_srcset_candidate(monkeypatch) -> None:

--- a/utils/create_bsky_post.py
+++ b/utils/create_bsky_post.py
@@ -15,11 +15,28 @@ import time
 from typing import Dict, List
 from datetime import datetime, timezone
 from urllib.parse import urlparse
+from urllib.parse import urljoin
 
 import requests
 from bs4 import BeautifulSoup
+from loguru import logger
 
 from monitoring.api_usage import record_api_event
+
+
+_DEFAULT_EXTERNAL_UA = (
+    "Mozilla/5.0 (X11; Linux x86_64; rv:135.0) Gecko/20100101 Firefox/135.0"
+)
+
+
+def _external_fetch_headers(*, referer: str | None = None) -> Dict[str, str]:
+    headers = {
+        "User-Agent": os.environ.get("BSKY_EMBED_USER_AGENT", _DEFAULT_EXTERNAL_UA),
+        "Accept-Language": "en-US,en;q=0.9",
+    }
+    if referer:
+        headers["Referer"] = referer
+    return headers
 
 
 def _tracked_request(method: str, url: str, **kwargs):
@@ -283,7 +300,7 @@ def upload_images(
     }
 
 
-def fetch_embed_url_card(pds_url: str, access_token: str, url: str) -> Dict:
+def fetch_embed_url_card(pds_url: str, access_token: str, url: str) -> Dict | None:
     # the required fields for an embed card
     card = {
         "uri": url,
@@ -292,8 +309,17 @@ def fetch_embed_url_card(pds_url: str, access_token: str, url: str) -> Dict:
     }
 
     # fetch the HTML
-    resp = _tracked_get(url)
-    resp.raise_for_status()
+    try:
+        resp = _tracked_get(
+            url,
+            headers=_external_fetch_headers(),
+            timeout=15,
+        )
+        resp.raise_for_status()
+    except requests.RequestException as exc:
+        logger.warning(f"Unable to fetch embed URL {url}: {exc}. Posting without external card.")
+        return None
+
     soup = BeautifulSoup(resp.text, "html.parser")
 
     title_tag = soup.find("meta", property="og:title")
@@ -308,10 +334,17 @@ def fetch_embed_url_card(pds_url: str, access_token: str, url: str) -> Dict:
     if image_tag:
         img_url = image_tag["content"]
         if "://" not in img_url:
-            img_url = url + img_url
-        resp = _tracked_get(img_url)
-        resp.raise_for_status()
-        card["thumb"] = upload_file(pds_url, access_token, img_url, resp.content)
+            img_url = urljoin(url, img_url)
+        try:
+            resp = _tracked_get(
+                img_url,
+                headers=_external_fetch_headers(referer=url),
+                timeout=15,
+            )
+            resp.raise_for_status()
+            card["thumb"] = upload_file(pds_url, access_token, img_url, resp.content)
+        except requests.RequestException as exc:
+            logger.warning(f"Unable to fetch external card image {img_url}: {exc}. Continuing without thumbnail.")
 
     return {
         "$type": "app.bsky.embed.external",
@@ -377,9 +410,11 @@ def create_post(args):
             args.pds_url, session["accessJwt"], args.image, args.alt_text
         )
     elif args.embed_url:
-        post["embed"] = fetch_embed_url_card(
+        embed_card = fetch_embed_url_card(
             args.pds_url, session["accessJwt"], args.embed_url
         )
+        if embed_card is not None:
+            post["embed"] = embed_card
     elif args.embed_ref:
         post["embed"] = get_embed_ref(args.pds_url, args.embed_ref)
 

--- a/utils/image_finder.py
+++ b/utils/image_finder.py
@@ -700,7 +700,7 @@ def _lookup_provider_image_url(provider: str, registration: str, config: dict[st
             provider=provider,
             request_url="https://www.jetphotos.com/showphotos.php",
             params=params,
-            headers=None,
+            headers=_build_headers(referer="https://www.jetphotos.com/", user_agent=config["user_agent"]),
             registration=registration,
             config=config,
         )


### PR DESCRIPTION
### Motivation

- Ensure external URL embeds are fetched with browser-like headers and timeouts to improve compatibility.  
- Make embed fetching resilient to network errors and blocked resources so posts can still be created without external cards.  
- Ensure provider scrapers send appropriate `User-Agent` and `Referer` headers.  
- Add tests to verify header usage and failure behavior for embed fetching and adjust existing image-finder tests accordingly.

### Description

- Added `_DEFAULT_EXTERNAL_UA` and helper `​_external_fetch_headers` to construct `User-Agent`, `Accept-Language`, and optional `Referer` headers.  
- Modified `fetch_embed_url_card` to use `urljoin` for relative image URLs, include `headers` and `timeout` on fetches, and wrap external requests in `try/except` to return `None` on failure while logging a warning via `logger`.  
- Adjusted `create_post` to only attach an embed when `fetch_embed_url_card` returns a non-`None` card.  
- Updated `image_finder` calls to `_request_with_retry` to pass headers via `_build_headers(referer=..., user_agent=...)` so scrapers include `User-Agent` and `Referer`.  
- Added `test/test_create_bsky_post.py` with tests for blocked-url behavior, continuing when embed fetch fails, and verifying browser-like headers; updated `test/test_image_finder.py` to assert header usage.

### Testing

- Ran `pytest test/test_create_bsky_post.py` which verifies embed fetch failure handling and header usage, and it passed.  
- Ran `pytest test/test_image_finder.py` which validates JetPhotos/Planespotters header behavior and it passed.  
- Ran the test suite with `pytest` for the modified tests and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a1a0c64420832aaa40376311a5dbd4)